### PR TITLE
Correct validate command options

### DIFF
--- a/src/cli/run/validate.ts
+++ b/src/cli/run/validate.ts
@@ -10,8 +10,9 @@ import validateTranslation from '../../services/translation/validate';
 
 const helperText = `
 Usage:
-    --validate-schema sample-widget/schema.json
-    --validate-query-params sample-widget/queryParamsBuilder.json
+    widget-builder validate --schema sample-widget
+    widget-builder validate --query-params sample-widget
+    widget-builder validate --translation sample-widget
 `;
 
 const validateCommands = () => {
@@ -24,12 +25,13 @@ const validateCommands = () => {
         .option('--translation', 'validates schema_translation.json file')
         .addHelpText('afterAll', helperText)
         .action((name, options) => {
-            const directory = path.resolve('.');
-            if (options.validateSchema) {
+            const directory = path.resolve('.', name);
+            
+            if (options.schema) {
                 validateSchema(directory);
             }
 
-            if (options.validateQueryParamsBuilder) {
+            if (options.queryParams) {
                 validateQueryParamsBuilder(directory);
             }
 


### PR DESCRIPTION
## What? Why?
The current options are incorrect and therefore validate commands do not run. Note: These currently need to be run inside the working directory of a widget and cannot be run in a parent directory. Running this command in a parent directory results in a generic error: "There was a problem loading the schema_translation.json file."

## Testing / Proof
Validate has been run with both schema and queryParams options on their associated files, with valid and invalid JSON, as specified by their corresponding schemas.

