### PR TITLE
Replace tracking with publish checks

### DIFF
--- a/src/services/widgetTemplate/publish.ts
+++ b/src/services/widgetTemplate/publish.ts
@@ -1,13 +1,12 @@
 import { log, messages } from '../../messages';
 import queryLoader from '../query/queryLoader/queryLoader';
 import queryParamsLoader from '../query/queryParamsLoader/queryParamsLoader';
-import { publishWidget } from '../api/widget';
+import { publishWidget, getWidgetTemplate } from '../api/widget';
 import WidgetFileType, { FileLoaderResponse } from '../../types';
 import schemaLoader from '../schema/schemaLoader/schemaLoader';
 
 import widgetTemplateLoader from './widgetTemplateLoader/widgetTemplateLoader';
 import translationsLoader from '../translation/translationLoader/translationLoader';
-import track from './track';
 
 interface CreateWidgetTemplateReq {
     name: string;
@@ -28,7 +27,7 @@ const widgetTemplatePayload = (widgetName: string): CreateWidgetTemplateReq => (
 });
 
 const publishWidgetTemplate = async (widgetName: string, widgetTemplateDir: string) => {
-    const widgetTemplateUuid = track.isTracked(widgetTemplateDir);
+    const widgetTemplateUuid = await getWidgetTemplate(widgetName);
 
     try {
         const widgetConfiguration = await Promise.all([
@@ -61,10 +60,9 @@ const publishWidgetTemplate = async (widgetName: string, widgetTemplateDir: stri
             }, widgetTemplatePayload(widgetName),
         ));
 
-        const { uuid } = await publishWidget(widgetConfiguration, widgetTemplateUuid);
+        await publishWidget(widgetConfiguration, widgetTemplateUuid);
 
         if (!widgetTemplateUuid) {
-            track.startTracking(widgetTemplateDir, uuid);
             log.success(messages.widgetRelease.success(widgetName));
         } else {
             log.success(`Successfully updated ${widgetName}`);


### PR DESCRIPTION
## What? Why?
...
The CLI tool currently checks for a widget.yml file containing a UUID. It then uses this UUID to perform a PUT or POST request depending on if it already exists or is new. We work with multiple environments and stores (staging, production, QA, trade/wholesale) and deploy through CI, meaning these IDs will either be wrong or the file will not exist. Removing the need to manage these files and relying on checks before publishing will simplify this process and eliminate any unnecessary complexity required with wrapper scripts. It also works better for developments running local deployments to test stores.

We have already diverged from bigcommerce/widget-builder, with the activity in the master repo being sparse. With that in mind, I haven't made this change compatible.