### PR TITLE
Resolve env loading and multi channel publishing

### DIFF
--- a/src/cli/deployment/widgetTemplatePublish.ts
+++ b/src/cli/deployment/widgetTemplatePublish.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 import publishWidgetTemplate from '../../services/widgetTemplate/publish';
 import { log, messages } from '../../messages';
 import checkCredentials from '../../services/auth/checkAuth';
-import AUTH_CONFIG from '../../services/auth/authConfig';
+import { AUTH_CONFIG } from '../../services/auth/authConfig';
 
 const widgetTemplatePublish = () => {
     const program = new Command('publish');

--- a/src/cli/run/start.ts
+++ b/src/cli/run/start.ts
@@ -6,7 +6,7 @@ import { Command } from 'commander';
 
 import startWidgetBuilder from '../../server';
 import checkCredentials from '../../services/auth/checkAuth';
-import AUTH_CONFIG from '../../services/auth/authConfig';
+import { AUTH_CONFIG } from '../../services/auth/authConfig';
 
 const startCommand = () => {
     const program = new Command('start');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,2 @@
 export const port: string = process.env.WIDGET_BUILDER_PORT || '8080';
 export const host: string = process.env.WIDGET_BUILDER_HOST || 'http://localhost';
-export const channelId = process.env.WIDGET_BUILDER_CHANNEL_ID ? parseInt(process.env.WIDGET_BUILDER_CHANNEL_ID, 10) : 1;

--- a/src/services/api/widget.test.ts
+++ b/src/services/api/widget.test.ts
@@ -1,4 +1,4 @@
-import AUTH_CONFIG from '../auth/authConfig';
+import { AUTH_CONFIG } from '../auth/authConfig';
 
 import { widgetApi } from './widget';
 

--- a/src/services/api/widget.ts
+++ b/src/services/api/widget.ts
@@ -1,6 +1,6 @@
 import Axios, { AxiosResponse } from 'axios';
 
-import AUTH_CONFIG from '../auth/authConfig';
+import { AUTH_CONFIG, CHANNEL_ID } from '../auth/authConfig';
 import { WidgetConfiguration } from '../schema/schemaParser/schemaParser';
 
 export const widgetApi = {
@@ -69,13 +69,13 @@ export const publishWidget = (
 
 export const getWidgetTemplate = (
     name: string
-): Promise<string> => new Promise((resolve, reject) => 
+): Promise<string> => new Promise((resolve, reject) =>
     getAllTemplates()
         .then((data) => {
             const match = data.find(
                 template => name === template.name,
-              );
-            
+            );
+
             resolve(match?.uuid || '');
         })
         .catch(error => reject(error)))
@@ -91,7 +91,7 @@ export interface WidgetTemplateResult {
     date_modified: string;
     current_version_uuid: string;
     icon_name: string;
-  }
+}
 
 const getAllTemplates = async (page: number = 1): Promise<WidgetTemplateResult[]> => {
     let listResults: WidgetTemplateResult[] = [];
@@ -105,7 +105,7 @@ const getAllTemplates = async (page: number = 1): Promise<WidgetTemplateResult[]
                 'X-Auth-Client': AUTH_CONFIG.authId,
                 'X-Auth-Token': AUTH_CONFIG.authToken,
             },
-            url: `${widgetApi.widgetTemplateList}?limit=250&page=${page}`,
+            url: `${widgetApi.widgetTemplateList}?limit=250&page=${page}&channel_id:in=${CHANNEL_ID}`,
         })).data;
 
         done = data.length === 0;

--- a/src/services/auth/authConfig.ts
+++ b/src/services/auth/authConfig.ts
@@ -8,10 +8,10 @@ export interface AuthConfig {
     authToken: string;
 }
 
-const AUTH_CONFIG: AuthConfig = {
+export const AUTH_CONFIG: AuthConfig = {
     authId: process.env.WIDGET_BUILDER_AUTH_ID || '',
     apiPath: process.env.WIDGET_BUILDER_API_GATEWAY_BASE || '',
     authToken: process.env.WIDGET_BUILDER_AUTH_TOKEN || '',
 };
 
-export default AUTH_CONFIG;
+export const CHANNEL_ID = process.env.WIDGET_BUILDER_CHANNEL_ID ? parseInt(process.env.WIDGET_BUILDER_CHANNEL_ID, 10) : 1;

--- a/src/services/widgetRenderer/widgetRenderer.ts
+++ b/src/services/widgetRenderer/widgetRenderer.ts
@@ -6,7 +6,7 @@ import widgetTemplateLoader from '../widgetTemplate/widgetTemplateLoader/widgetT
 import widgetConfigLoader from '../widgetConfig/widgetConfigLoader/widgetConfigLoader';
 import queryLoader from '../query/queryLoader/queryLoader';
 import queryParamsLoader from '../query/queryParamsLoader/queryParamsLoader';
-import { channelId } from '../../config';
+import { CHANNEL_ID } from '../../services/auth/authConfig';
 import translationsLoader from '../translation/translationLoader/translationLoader';
 
 const getInitialRenderingPayload = (): WidgetPreviewRenderRequest => ({
@@ -16,7 +16,7 @@ const getInitialRenderingPayload = (): WidgetPreviewRenderRequest => ({
     widget_uuid: uuid(),
     storefront_api_query: '',
     storefront_api_query_params: {},
-    channel_id: channelId,
+    channel_id: CHANNEL_ID,
     schema_translations: '',
 });
 

--- a/src/services/widgetTemplate/publish.ts
+++ b/src/services/widgetTemplate/publish.ts
@@ -4,7 +4,7 @@ import queryParamsLoader from '../query/queryParamsLoader/queryParamsLoader';
 import { publishWidget, getWidgetTemplate } from '../api/widget';
 import WidgetFileType, { FileLoaderResponse } from '../../types';
 import schemaLoader from '../schema/schemaLoader/schemaLoader';
-import { channelId } from '../../config';
+import { CHANNEL_ID } from '../../services/auth/authConfig';
 import translationsLoader from '../translation/translationLoader/translationLoader';
 
 import widgetTemplateLoader from './widgetTemplateLoader/widgetTemplateLoader';
@@ -24,7 +24,7 @@ const widgetTemplatePayload = (widgetName: string): CreateWidgetTemplateReq => (
     schema: [],
     template: '',
     storefront_api_query: '',
-    channel_id: channelId,
+    channel_id: CHANNEL_ID,
     schema_translations: '',
 });
 


### PR DESCRIPTION
## What? Why?
Multi-channel widget publishing wasn't working. There were two separate problems here:
- Environment variables are loaded using dotenv but only inside authConfig. Due to the way ES6 module resolution and eval works, any env vars referenced outside this file would return undefined. Therefore, only default values were ever loaded. Channels other than 1 did not work!
- Widget templates required matching to channel ids so that they update the correct template when using different templates/widget instances on different channels

